### PR TITLE
Support localized custom value

### DIFF
--- a/py_appstream/component.py
+++ b/py_appstream/component.py
@@ -121,7 +121,22 @@ class Component(Node):
             elif c1.tag == 'custom':
                 for c2 in c1:
                     if c2.tag == 'value' and 'key' in c2.attrib:
-                        self.custom[c2.get('key')] = c2.text.strip()
+                        key = c2.get('key')
+                        lang = c2.get('{http://www.w3.org/XML/1998/namespace}lang', c2.attrib.get('lang'))
+                        if lang is None and (key not in self.custom or isinstance(self.custom[key], str)):
+                            # add as simple string
+                            self.custom[key] = c2.text.strip()
+                        else:
+                            # add as language-value dict
+                            values = self.custom.get(key)
+                            if values is None:
+                                values = {}
+                            elif isinstance(values, str):
+                                # convert existing string value to dict value
+                                clang = lang_code_func('C') if lang_code_func else 'C'
+                                values = {clang: values}
+                            utils.localize(values, c2, lang_code_func=lang_code_func)
+                            self.custom[key] = values
             elif c1.tag == 'pkgname':
                 self.pkgname = val
             elif c1.tag == 'keywords':

--- a/tests/test.appdata.xml
+++ b/tests/test.appdata.xml
@@ -149,4 +149,13 @@
         <release version="1.1" type="development" date="2013-10-20" />
         <release version="1.0" date="2012-08-26" />
     </releases>
+    <custom>
+        <value key="KDE::duplicate_value">value1</value>
+        <value key="KDE::duplicate_value">value2</value>
+        <value key="KDE::windows_store::screenshots::1::image">https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Timeline.png</value>
+        <value key="KDE::windows_store::screenshots::1::caption">Main view with room list, chat, and room information pane</value>
+        <value key="KDE::windows_store::screenshots::2::image">https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Login.png</value>
+        <value key="KDE::windows_store::screenshots::2::caption">Login screen</value>
+        <value key="KDE::windows_store::screenshots::2::caption" xml:lang="de">Anmeldebildschirm</value>
+     </custom>
 </component>

--- a/tests/test.py
+++ b/tests/test.py
@@ -92,9 +92,20 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual(4, len(self.component.screenshots))
         self.assertEqual(3, len(self.component.releases))
         # serialization
-        self.assertEqual(17, len(self.obj.keys()))
+        self.assertEqual(18, len(self.obj.keys()))
         self.assertEqual(4, len(self.obj['Keywords']['C']))
 
+    def test_custom_values(self):
+        custom = self.component.custom
+        self.assertEqual(5, len(custom.keys()))
+        # normal custom value
+        self.assertEqual('https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Timeline.png', custom.get('KDE::windows_store::screenshots::1::image'))
+        # (localized) custom value without translations
+        self.assertEqual('Main view with room list, chat, and room information pane', custom.get('KDE::windows_store::screenshots::1::caption'))
+        # localized custom value with one translation
+        self.assertEqual({'C': 'Login screen', 'de': 'Anmeldebildschirm'}, custom.get('KDE::windows_store::screenshots::2::caption'))
+        # duplicate entry of (unlocalized) custom value
+        self.assertEqual('value2', custom.get('KDE::duplicate_value'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Unlocalized custom values (i.e. without xml:lang or lang attribute) are added as string values to the custom values dict (as before). This way nothing changes for existing custom values (even for accidentally duplicated custom values).

Localized custom values are added as a language-value dict to the custom values dict.

Localized custom values will be introduced with
https://invent.kde.org/network/neochat/-/merge_requests/1060