### PR TITLE
Support screenshots with custom x-kde-os attribute

### DIFF
--- a/py_appstream/component.py
+++ b/py_appstream/component.py
@@ -121,22 +121,7 @@ class Component(Node):
             elif c1.tag == 'custom':
                 for c2 in c1:
                     if c2.tag == 'value' and 'key' in c2.attrib:
-                        key = c2.get('key')
-                        lang = c2.get('{http://www.w3.org/XML/1998/namespace}lang', c2.attrib.get('lang'))
-                        if lang is None and (key not in self.custom or isinstance(self.custom[key], str)):
-                            # add as simple string
-                            self.custom[key] = c2.text.strip()
-                        else:
-                            # add as language-value dict
-                            values = self.custom.get(key)
-                            if values is None:
-                                values = {}
-                            elif isinstance(values, str):
-                                # convert existing string value to dict value
-                                clang = lang_code_func('C') if lang_code_func else 'C'
-                                values = {clang: values}
-                            utils.localize(values, c2, lang_code_func=lang_code_func)
-                            self.custom[key] = values
+                        self.custom[c2.get('key')] = c2.text.strip()
             elif c1.tag == 'pkgname':
                 self.pkgname = val
             elif c1.tag == 'keywords':

--- a/py_appstream/subcomponent.py
+++ b/py_appstream/subcomponent.py
@@ -190,10 +190,12 @@ class Screenshot(Node):
         self.caption = {}
         self.thumbnails = []
         self.source = None
+        self.os = ''
 
     def parse_tree(self, node, lang_code_func=None):
         """ Parse a <screenshot> object """
         self.default = node.get('type', '') == 'default'
+        self.os = node.get('x-kde-os', '')
         for c3 in node:
             if c3.tag == 'caption':
                 utils.localize(self.caption, c3, lang_code_func=lang_code_func)

--- a/tests/test.appdata.xml
+++ b/tests/test.appdata.xml
@@ -149,13 +149,4 @@
         <release version="1.1" type="development" date="2013-10-20" />
         <release version="1.0" date="2012-08-26" />
     </releases>
-    <custom>
-        <value key="KDE::duplicate_value">value1</value>
-        <value key="KDE::duplicate_value">value2</value>
-        <value key="KDE::windows_store::screenshots::1::image">https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Timeline.png</value>
-        <value key="KDE::windows_store::screenshots::1::caption">Main view with room list, chat, and room information pane</value>
-        <value key="KDE::windows_store::screenshots::2::image">https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Login.png</value>
-        <value key="KDE::windows_store::screenshots::2::caption">Login screen</value>
-        <value key="KDE::windows_store::screenshots::2::caption" xml:lang="de">Anmeldebildschirm</value>
-     </custom>
 </component>

--- a/tests/test.appdata.xml
+++ b/tests/test.appdata.xml
@@ -108,6 +108,10 @@
             <caption xml:lang="x-test">xx"Mixing color of paint" activityxx</caption>
             <image width="1600" height="1040">https://gcompris.net/screenshots_qt/large/color_mix.png</image>
         </screenshot>
+        <screenshot x-kde-os="windows">
+            <caption>Main view with room list, chat, and room information pane</caption>
+            <image>https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Timeline.png</image>
+        </screenshot>
     </screenshots>
     <provides>
         <binary>firefox</binary>

--- a/tests/test.py
+++ b/tests/test.py
@@ -92,20 +92,9 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual(4, len(self.component.screenshots))
         self.assertEqual(3, len(self.component.releases))
         # serialization
-        self.assertEqual(18, len(self.obj.keys()))
+        self.assertEqual(17, len(self.obj.keys()))
         self.assertEqual(4, len(self.obj['Keywords']['C']))
 
-    def test_custom_values(self):
-        custom = self.component.custom
-        self.assertEqual(5, len(custom.keys()))
-        # normal custom value
-        self.assertEqual('https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Timeline.png', custom.get('KDE::windows_store::screenshots::1::image'))
-        # (localized) custom value without translations
-        self.assertEqual('Main view with room list, chat, and room information pane', custom.get('KDE::windows_store::screenshots::1::caption'))
-        # localized custom value with one translation
-        self.assertEqual({'C': 'Login screen', 'de': 'Anmeldebildschirm'}, custom.get('KDE::windows_store::screenshots::2::caption'))
-        # duplicate entry of (unlocalized) custom value
-        self.assertEqual('value2', custom.get('KDE::duplicate_value'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -53,10 +53,13 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual('O l\'actiu La comunitat d\'artistes del Krita anchor', screenshots[2].caption['ca'])
         # Exclude empty string
         self.assertEqual({'C', 'ca'}, set(screenshots[2].caption.keys()))
+        # x-kde-os attribute
+        self.assertEqual('windows', self.component.screenshots[4].os)
         # serialization
         self.assertIn('source-image', self.obj['Screenshots'][0])
         self.assertEqual('https://gcompris.net/screenshots_qt/large/color_mix.png',
                          self.obj['Screenshots'][3]['source-image']['url'])
+        self.assertEqual('windows', self.obj['Screenshots'][4]['os'])
 
     def test_provide(self):
         provide = self.component.provides
@@ -89,7 +92,7 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual('KDE', self.component.project_group)
         self.assertEqual(5, len(self.component.name.keys()))
         self.assertEqual({}, self.component.developer_name)
-        self.assertEqual(4, len(self.component.screenshots))
+        self.assertEqual(5, len(self.component.screenshots))
         self.assertEqual(3, len(self.component.releases))
         # serialization
         self.assertEqual(17, len(self.obj.keys()))


### PR DESCRIPTION
This adds support for the custom `x-kde-os` attribute for screenshots which we will use to mark Windows-specific screenshots (for use in the Microsoft Store) and other OS-specific screenshots.

This removes the previous change which added support for localized custom values because this will most likely never be supported by appstream (see https://github.com/ximion/appstream/pull/514).