### PR TITLE
Add support for new environment attribute for screenshots

### DIFF
--- a/py_appstream/subcomponent.py
+++ b/py_appstream/subcomponent.py
@@ -190,12 +190,12 @@ class Screenshot(Node):
         self.caption = {}
         self.thumbnails = []
         self.source = None
-        self.os = ''
+        self.environment = ''
 
     def parse_tree(self, node, lang_code_func=None):
         """ Parse a <screenshot> object """
         self.default = node.get('type', '') == 'default'
-        self.os = node.get('x-kde-os', '')
+        self.environment = node.get('environment', '')
         for c3 in node:
             if c3.tag == 'caption':
                 utils.localize(self.caption, c3, lang_code_func=lang_code_func)

--- a/tests/test.appdata.xml
+++ b/tests/test.appdata.xml
@@ -108,7 +108,7 @@
             <caption xml:lang="x-test">xx"Mixing color of paint" activityxx</caption>
             <image width="1600" height="1040">https://gcompris.net/screenshots_qt/large/color_mix.png</image>
         </screenshot>
-        <screenshot x-kde-os="windows">
+        <screenshot environment="windows">
             <caption>Main view with room list, chat, and room information pane</caption>
             <image>https://cdn.kde.org/screenshots/neochat/NeoChat-Windows-Timeline.png</image>
         </screenshot>

--- a/tests/test.py
+++ b/tests/test.py
@@ -53,13 +53,13 @@ class ComponentTestCase(unittest.TestCase):
         self.assertEqual('O l\'actiu La comunitat d\'artistes del Krita anchor', screenshots[2].caption['ca'])
         # Exclude empty string
         self.assertEqual({'C', 'ca'}, set(screenshots[2].caption.keys()))
-        # x-kde-os attribute
-        self.assertEqual('windows', self.component.screenshots[4].os)
+        # environment attribute
+        self.assertEqual('windows', self.component.screenshots[4].environment)
         # serialization
         self.assertIn('source-image', self.obj['Screenshots'][0])
         self.assertEqual('https://gcompris.net/screenshots_qt/large/color_mix.png',
                          self.obj['Screenshots'][3]['source-image']['url'])
-        self.assertEqual('windows', self.obj['Screenshots'][4]['os'])
+        self.assertEqual('windows', self.obj['Screenshots'][4]['environment'])
 
     def test_provide(self):
         provide = self.component.provides


### PR DESCRIPTION
appstream now officially supports an environment attribute for screenshots.

See https://github.com/ximion/appstream/pull/530